### PR TITLE
Missing stdlib requires

### DIFF
--- a/lib/bogus.rb
+++ b/lib/bogus.rb
@@ -1,4 +1,6 @@
 require 'dependor'
+require 'erb'
+require 'set'
 
 require_relative 'bogus/takes'
 require_relative 'bogus/record_interactions'


### PR DESCRIPTION
This adds two missing standard library requires: `NotAllExpectationsSatisfied` uses `ERB` and `Shadow` uses `Set`.
