### PR TITLE
Ruby 2.0 keyword arguments support

### DIFF
--- a/lib/bogus/method_stringifier.rb
+++ b/lib/bogus/method_stringifier.rb
@@ -17,6 +17,7 @@ module Bogus
     def argument_to_string(name, type)
       case type
       when :block then "&#{name}"
+      when :key   then "#{name}: #{name}"
       when :opt   then "#{name} = {}"
       when :req   then name
       when :rest  then "*#{name}"

--- a/lib/bogus/verifies_stub_definition.rb
+++ b/lib/bogus/verifies_stub_definition.rb
@@ -32,7 +32,7 @@ class Bogus::VerifiesStubDefinition
 
   def over_number_of_allowed_arguments?(method, args_count)
     return false if method.parameters.find{|type, name| type == :rest}
-    number_of_arguments = method.parameters.count{|type, name| [:opt, :req].include?(type) }
+    number_of_arguments = method.parameters.count{|type, name| [:key, :opt, :req].include?(type) }
 
     args_count > number_of_arguments
   end


### PR DESCRIPTION
These seem to be minimal changes required for getting Ruby 2.0 keyword arguments working; I suck when it comes to Cucumber feature writing but I’ll follow up with something when I have a bit of time.
