### PR TITLE
Saner keyword arguments support

### DIFF
--- a/lib/bogus/method_stringifier.rb
+++ b/lib/bogus/method_stringifier.rb
@@ -17,7 +17,7 @@ module Bogus
     def argument_to_string(name, type)
       case type
       when :block then "&#{name}"
-      when :key   then "#{name}: #{name}"
+      when :key   then "#{name}: Bogus::Anything"
       when :opt   then "#{name} = {}"
       when :req   then name
       when :rest  then "*#{name}"


### PR DESCRIPTION
Apologies for the previous implementation, it worked more by accident than anything else (it required the existence of a method named the same was as the argument, which happened to be the case in all of my specs…).

This allows the kwargs to be anything, which is still sub-optimal¹, but better than what’s on master at the moment.

¹ ideally, the stringifier would default them to their actual default values – but I failed to find a stable way to do it with the method_source gem; the other idea was to parse `Ripper.sexp` output fed with `Method#source_location`, but that might be more work than it’s worth ;)
