### PR TITLE
Warnings-clean

### DIFF
--- a/lib/bogus/active_record_accessors.rb
+++ b/lib/bogus/active_record_accessors.rb
@@ -20,6 +20,7 @@ module Bogus
 
     private
 
+    undef :instance_methods if defined? :instance_methods
     def instance_methods
       @instance_methods.call(klass)
     end


### PR DESCRIPTION
This is ugly, but makes Bogus `ruby -w` clean again (`instance_methods` is defined by Dependor; maybe there’s a way to make it not define the getter in this case?).
