### PR TITLE
Update RSpec to use expect syntax, 'eq' over '==' and 'match' or 'match_array' over '=~'

### DIFF
--- a/spec/bogus/clean_ruby_spec.rb
+++ b/spec/bogus/clean_ruby_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe "Ruby syntax" do
   it "is clean" do
-    bogus_warnings.should == []
+    expect(bogus_warnings).to eq []
   end
 
   def bogus_warnings
-    warnings.select { |w| w =~ %r{lib/bogus} }
+    warnings.select { |w| w match(%r{lib/bogus}) }
   end
 
   def warnings

--- a/spec/bogus/configuration_spec.rb
+++ b/spec/bogus/configuration_spec.rb
@@ -8,10 +8,10 @@ describe Bogus::Configuration do
       c.search_modules << String
     end
 
-    Bogus.config.search_modules.should == [Object, String]
+    expect(Bogus.config.search_modules).to eq [Object, String]
   end
 
   it "defaults search_modules to [Object]" do
-    Bogus.config.search_modules.should == [Object]
+    expect(Bogus.config.search_modules).to eq [Object]
   end
 end

--- a/spec/bogus/contracts/adds_contract_verification_spec.rb
+++ b/spec/bogus/contracts/adds_contract_verification_spec.rb
@@ -37,7 +37,7 @@ describe Bogus::AddsContractVerification do
     it "verifies the contract in after_suite" do
       syntax.run_after_suite
 
-      verifies_contracts.should have_received.verify(:some_fake)
+      expect(verifies_contracts).to have_received.verify(:some_fake)
     end
   end
 
@@ -72,14 +72,14 @@ describe Bogus::AddsContractVerification do
     it "overwrites described_class in before" do
       syntax.run_before
 
-      syntax.described_class.should == overwritten_class
+      expect(syntax.described_class).to eq overwritten_class
     end
 
     it "resets described_class in after" do
       syntax.run_before
       syntax.run_after
 
-      syntax.described_class.should == SomeClass
+      expect(syntax.described_class).to eq SomeClass
     end
 
     it_verifies_contract_after_suite
@@ -87,7 +87,7 @@ describe Bogus::AddsContractVerification do
     it "adds recording to described_class" do
       syntax.run_before
 
-      adds_recording.should have_received.add(:some_fake, SomeClass)
+      expect(adds_recording).to have_received.add(:some_fake, SomeClass)
     end
   end
 
@@ -104,14 +104,14 @@ describe Bogus::AddsContractVerification do
     it "does not overwrite described_class in before" do
       syntax.run_before
 
-      syntax.described_class.should == SomeClass
+      expect(syntax.described_class).to eq SomeClass
     end
 
     it "does not change described_class in after" do
       syntax.run_before
       syntax.run_after
 
-      syntax.described_class.should == SomeClass
+      expect(syntax.described_class).to eq SomeClass
     end
 
     it_verifies_contract_after_suite
@@ -119,7 +119,7 @@ describe Bogus::AddsContractVerification do
     it "adds recording to custom class" do
       syntax.run_before
 
-      adds_recording.should have_received.add(:some_fake, ClassToOverwrite)
+      expect(adds_recording).to have_received.add(:some_fake, ClassToOverwrite)
     end
   end
 
@@ -133,14 +133,14 @@ describe Bogus::AddsContractVerification do
     it "does not overwrite described_class in before" do
       syntax.run_before
 
-      syntax.described_class.should be_nil
+      expect(syntax.described_class).to be_nil
     end
 
     it "does not change described_class in after" do
       syntax.run_before
       syntax.run_after
 
-      syntax.described_class.should be_nil
+      expect(syntax.described_class).to be_nil
     end
 
     it_verifies_contract_after_suite
@@ -148,7 +148,7 @@ describe Bogus::AddsContractVerification do
     it "adds recording to class based on fake name" do
       syntax.run_before
 
-      adds_recording.should have_received.add(:some_fake, ClassGuessedFromFakeName)
+      expect(adds_recording).to have_received.add(:some_fake, ClassGuessedFromFakeName)
     end
   end
 end

--- a/spec/bogus/contracts/adds_recording_spec.rb
+++ b/spec/bogus/contracts/adds_recording_spec.rb
@@ -26,18 +26,18 @@ describe Bogus::AddsRecording do
   end
 
   it "creates the proxy" do
-    create_proxy_class.should have_received.call(:library, SampleModule::Library)
+    expect(create_proxy_class).to have_received.call(:library, SampleModule::Library)
   end
 
   it "swaps the classes" do
-    overwrites_classes.should have_received.overwrite('SampleModule::Library', Object)
+    expect(overwrites_classes).to have_received.overwrite('SampleModule::Library', Object)
   end
 
   it "records the overwritten class, so that it can be later restored" do
-    overwritten_classes.should have_received.add("SampleModule::Library", SampleModule::Library)
+    expect(overwritten_classes).to have_received.add("SampleModule::Library", SampleModule::Library)
   end
 
   it "returns the proxy class" do
-    adds_recording.add(:library, SampleModule::Library).should == Object
+    expect(adds_recording.add(:library, SampleModule::Library)).to eq Object
   end
 end

--- a/spec/bogus/contracts/interactions_repository_spec.rb
+++ b/spec/bogus/contracts/interactions_repository_spec.rb
@@ -10,80 +10,80 @@ describe Bogus::InteractionsRepository do
   it "considers the interaction recorded if it was recorded previously" do
     interactions_repository.record(:foo, :bar, 1, 2, 3)
 
-    recorded?(:foo, :bar, 1, 2, 3).should be_true
+    expect(recorded?(:foo, :bar, 1, 2, 3)).to be_true
   end
 
   it "considers the interaction recorded if it returned the same value as passed block" do
     interactions_repository.record(:foo, :bar) { "a result" }
     interaction = Bogus::Interaction.new(:bar, []) { "a result" }
 
-    interactions_repository.recorded?(:foo, interaction).should be_true
+    expect(interactions_repository.recorded?(:foo, interaction)).to be_true
   end
 
   it "does not consider any interactions recorded prior to any recordings" do
-    recorded?(:foo, :bar, 1).should be_false
+    expect(recorded?(:foo, :bar, 1)).to be_false
   end
 
   it "does not consider the interaction recorded with a different fake name"  do
     interactions_repository.record(:baz, :bar, 1)
 
-    recorded?(:foo, :bar, 1).should be_false
+    expect(recorded?(:foo, :bar, 1)).to be_false
   end
 
   it "does not consider the interaction recorded with a different method name" do
     interactions_repository.record(:foo, :baz, 1)
 
-    recorded?(:foo, :bar, 1).should be_false
+    expect(recorded?(:foo, :bar, 1)).to be_false
   end
 
   it "does not consider the interaction recorded with different method arguments" do
     interactions_repository.record(:foo, :bar, 1, 2)
 
-    recorded?(:foo, :bar, 1).should be_false
+    expect(recorded?(:foo, :bar, 1)).to be_false
   end
 
   it "returns a list of interactions for given fake" do
     interactions_repository.record(:foo, :bar, 1, 2)
 
     interactions = interactions_repository.for_fake(:foo)
-    interactions.should have(1).item
-    interactions.first.method.should == :bar
-    interactions.first.args.should == [1, 2]
+    expect(interactions).to have(1).item
+    expect(interactions.first.method).to eq :bar
+    expect(interactions.first.args).to eq [1, 2]
   end
 
   it "ignores arguments if the checked interaction has any_args" do
     interactions_repository.record(:foo, :bar, 1)
 
-    recorded?(:foo, :bar, Bogus::AnyArgs).should be_true
+    expect(recorded?(:foo, :bar, Bogus::AnyArgs)).to be_true
   end
 
   it "takes method name into account when matching interaction with wildcard arguments" do
     interactions_repository.record(:foo, :baz, 1)
 
-    recorded?(:foo, :bar, Bogus::AnyArgs).should be_false
+    expect(recorded?(:foo, :bar, Bogus::AnyArgs)).to be_false
   end
 
   it "ignores arguments if the recorded interaction was recorded with wildcard argument" do
     interactions_repository.record(:foo, :bar, 1, 2)
 
-    recorded?(:foo, :bar, 1, Bogus::Anything).should be_true
+    expect(recorded?(:foo, :bar, 1, Bogus::Anything)).to be_true
   end
 
   it "takes other arguments into account when matching interactions with wildcards" do
     interactions_repository.record(:foo, :bar, 1, 2)
 
-    recorded?(:foo, :bar, 2, Bogus::Anything).should be_false
+    expect(recorded?(:foo, :bar, 2, Bogus::Anything)).to be_false
   end
 
   it "ignores arguments if the checked interaction has any_args" do
     interactions_repository.record(:foo, :bar, 1, 2)
 
-    recorded?(:foo, :bar, 1, Bogus::Anything).should be_true
+    expect(recorded?(:foo, :bar, 1, Bogus::Anything)).to be_true
   end
 
   it "takes method name into account when matching interaction with wildcard arguments" do
     interactions_repository.record(:foo, :baz, 1, 2)
 
-    recorded?(:foo, :bar, 1, Bogus::Anything).should be_false
+    expect(recorded?(:foo, :bar, 1, Bogus::Anything)).to be_false
   end
 end

--- a/spec/bogus/contracts/proxy_class_spec.rb
+++ b/spec/bogus/contracts/proxy_class_spec.rb
@@ -28,33 +28,33 @@ describe Bogus::ProxyClass do
   let(:interactions_repository) { FakeRepository.new }
 
   it "returns the proxy" do
-    proxy_class.new.checkout("Moby Dick", "Bob").should == :checkouted
+    expect(proxy_class.new.checkout("Moby Dick", "Bob")).to eq :checkouted
   end
 
   it "records interactions with created objects" do
     proxy_class.new.checkout("Moby Dick", "Bob")
 
-    interactions_repository.should have_recorded(:fake_name, :checkout, "Moby Dick", "Bob")
+    expect(interactions_repository).to have_recorded(:fake_name, :checkout, "Moby Dick", "Bob")
   end
 
   it "responds to every method that the original class responds to" do
-    proxy_class.should respond_to(:find_by_address)
+    expect(proxy_class).to respond_to(:find_by_address)
   end
 
   it "delegates interactions with the proxy class to wrapped class" do
-    proxy_class.find_by_address("some address").should == :the_library
+    expect(proxy_class.find_by_address("some address")).to eq :the_library
   end
 
   it "records interactions with the proxy class" do
     proxy_class.find_by_address("some address")
 
-    interactions_repository.should have_recorded(:fake_name, :find_by_address, "some address")
+    expect(interactions_repository).to have_recorded(:fake_name, :find_by_address, "some address")
   end
 
   it "records return values" do
     proxy_class.find_by_address("some address")
 
-    interactions_repository.return_value(:fake_name, :find_by_address, "some address").should == :the_library
+    expect(interactions_repository.return_value(:fake_name, :find_by_address, "some address")).to eq :the_library
   end
 
   it "re-raises exceptions" do
@@ -72,7 +72,7 @@ describe Bogus::ProxyClass do
   end
 
   it "allows accessing the constants defined on proxied class" do
-    proxy_class::SAMPLE_CONSTANT.should == "foo"
+    expect(proxy_class::SAMPLE_CONSTANT).to eq "foo"
   end
 
   class FakeRepository

--- a/spec/bogus/contracts/records_double_interactions_spec.rb
+++ b/spec/bogus/contracts/records_double_interactions_spec.rb
@@ -13,7 +13,7 @@ describe Bogus::RecordsDoubleInteractions do
 
     records_double_interactions.record(object, :method_name, [:foo, 1])
 
-    doubled_interactions.should have_received.record(:object_name, :method_name, :foo, 1)
+    expect(doubled_interactions).to have_received.record(:object_name, :method_name, :foo, 1)
   end
 
   it "does not record the interaction if object is not a fake" do

--- a/spec/bogus/contracts/verifies_contracts_spec.rb
+++ b/spec/bogus/contracts/verifies_contracts_spec.rb
@@ -37,9 +37,9 @@ describe Bogus::VerifiesContracts do
     verifies_contracts.verify(name)
     fail
   rescue Bogus::ContractNotFulfilled => contract_error
-    contract_error.fake_name.should == name
-    contract_error.missed_interactions.should == missed
-    contract_error.actual_interactions.should == real
+    expect(contract_error.fake_name).to eq name
+    expect(contract_error.missed_interactions).to eq missed
+    expect(contract_error.actual_interactions).to eq real
   end
 
   def interaction(method)

--- a/spec/bogus/fakes/base_class_identifier_spec.rb
+++ b/spec/bogus/fakes/base_class_identifier_spec.rb
@@ -45,7 +45,7 @@ module SampleForBaseIdentifier
         it "returns the same for is_a?(#{klass})" do
           expected = instance.is_a?(klass)
           actual = Bogus::BaseClassIdentifier.base_class?(copied_class, klass)
-          actual.should == expected
+          expect(actual).to eq expected
         end
       end
     end

--- a/spec/bogus/fakes/class_methods_spec.rb
+++ b/spec/bogus/fakes/class_methods_spec.rb
@@ -22,18 +22,17 @@ module Bogus
     let(:class_methods) { ClassMethods.new(SampleClass) }
 
     it "lists the class methods excluding the ones added by Bogus" do
-      class_methods.all.should =~ [:bar, :hello]
+      expect(class_methods.all).to match_array([:bar, :hello])
     end
 
     it "returns the instance methods by name" do
-      class_methods.get(:bar).should ==
-        SampleClass.method(:bar)
+      expect(class_methods.get(:bar)).to eq SampleClass.method(:bar)
     end
 
     it "removes methods by name" do
       class_methods.remove(:hello)
 
-      SampleClass.should_not respond_to(:hello)
+      expect(SampleClass).to_not respond_to(:hello)
     end
 
     it "defines instance methods" do
@@ -43,7 +42,7 @@ module Bogus
       end
       EOF
 
-      SampleClass.greet("Joe").should == "Hello, Joe!"
+      expect(SampleClass.greet("Joe")).to eq "Hello, Joe!"
     end
   end
 end

--- a/spec/bogus/fakes/converts_name_to_class_spec.rb
+++ b/spec/bogus/fakes/converts_name_to_class_spec.rb
@@ -15,19 +15,19 @@ describe Bogus::ConvertsNameToClass do
   it "finds classes in golbal namespace by default" do
     converts_name_to_class = Bogus::ConvertsNameToClass.new(Bogus.config.search_modules)
 
-    converts_name_to_class.convert(:foo_bar_baz).should == FooBarBaz
+    expect(converts_name_to_class.convert(:foo_bar_baz)).to eq FooBarBaz
   end
 
   it "looks in the modules in the specified order" do
     converts_name_to_class = Bogus::ConvertsNameToClass.new([Foo, Bar])
 
-    converts_name_to_class.convert(:foo_bar_baz).should == Foo::FooBarBaz
+    expect(converts_name_to_class.convert(:foo_bar_baz)).to eq Foo::FooBarBaz
   end
 
   it "looks in the next module on the list if the first does not contain the class" do
     converts_name_to_class = Bogus::ConvertsNameToClass.new([Foo, Bar])
 
-    converts_name_to_class.convert(:bam).should == Bar::Bam
+    expect(converts_name_to_class.convert(:bam)).to eq Bar::Bam
   end
 
   it "raises an error if it can't find the class" do

--- a/spec/bogus/fakes/copies_classes_spec.rb
+++ b/spec/bogus/fakes/copies_classes_spec.rb
@@ -20,33 +20,33 @@ describe Bogus::CopiesClasses do
 
   shared_examples_for 'the copied class' do
     it "copies methods with no arguments" do
-      subject.should respond_to(:foo)
+      expect(subject).to respond_to(:foo)
       subject.foo
     end
 
     it "copies methods with explicit arguments" do
-      subject.should respond_to(:bar)
+      expect(subject).to respond_to(:bar)
 
-      subject.method(:bar).arity.should == 1
+      expect(subject.method(:bar).arity).to eq 1
 
       subject.bar('hello')
     end
 
     it "copies methods with variable arguments" do
-      subject.should respond_to(:baz)
+      expect(subject).to respond_to(:baz)
 
       subject.baz('hello', 'foo', 'bar', 'baz')
     end
 
     it "copies methods with default arguments" do
-      subject.should respond_to(:bam)
+      expect(subject).to respond_to(:bam)
 
       subject.bam
       subject.bam(hello: 'world')
     end
 
     it "copies methods with block arguments" do
-      subject.should respond_to(:baa)
+      expect(subject).to respond_to(:baa)
 
       subject.baa('hello')
       subject.baa('hello') {}
@@ -66,7 +66,7 @@ describe Bogus::CopiesClasses do
     let(:klass) { FooWithInstanceMethods }
 
     it "does not overwrite nested constants" do
-      fake_class::CONST.should == "the const"
+      expect(fake_class::CONST).to eq "the const"
     end
   end
 
@@ -91,13 +91,13 @@ describe Bogus::CopiesClasses do
     it "adds a no-arg constructor" do
       instance = fake_class.__create__
 
-      instance.should respond_to(:foo)
+      expect(instance).to respond_to(:foo)
     end
 
     it "adds a constructor that allows passing the correct number of arguments" do
       instance = fake_class.new('hello')
 
-      instance.should respond_to(:foo)
+      expect(instance).to respond_to(:foo)
     end
   end
 
@@ -121,31 +121,31 @@ describe Bogus::CopiesClasses do
     let(:klass) { SomeModule::SomeClass }
 
     it "should copy the class name" do
-      fake.class.name.should == 'SomeModule::SomeClass'
+      expect(fake.class.name).to eq 'SomeModule::SomeClass'
     end
 
     it "should override kind_of?" do
-      fake.kind_of?(SomeModule::SomeClass).should be_true
+      expect(fake.kind_of?(SomeModule::SomeClass)).to be_true
     end
 
     it "should override instance_of?" do
-      fake.instance_of?(SomeModule::SomeClass).should be_true
+      expect(fake.instance_of?(SomeModule::SomeClass)).to be_true
     end
 
     it "should override is_a?" do
-      fake.is_a?(SomeModule::SomeClass).should be_true
+      expect(fake.is_a?(SomeModule::SomeClass)).to be_true
     end
 
     it "should include class name in the output of fake's class #to_s" do
-      fake.class.to_s.should include(klass.name)
+      expect(fake.class.to_s).to include(klass.name)
     end
 
     it "should include class name in the output of fake's #to_s" do
-      fake.to_s.should include(klass.name)
+      expect(fake.to_s).to include(klass.name)
     end
 
     it 'should override ===' do
-      SomeModule::SomeClass.should === fake
+      expect(SomeModule::SomeClass === fake).to be_true
     end
   end
 
@@ -197,7 +197,7 @@ describe Bogus::CopiesClasses do
     let(:klass) { SomeModel }
 
     it "copies those methods" do
-      fake.should respond_to(:save)
+      expect(fake).to respond_to(:save)
     end
   end
 end

--- a/spec/bogus/fakes/creates_fakes_spec.rb
+++ b/spec/bogus/fakes/creates_fakes_spec.rb
@@ -23,15 +23,15 @@ describe Bogus::CreatesFakes do
     end
 
     it "creates a new instance of copied class by default" do
-      creates_fakes.create(:foo).should == fake_instance
+      expect(creates_fakes.create(:foo)).to eq fake_instance
     end
 
     it "creates a new instance of copied class if called with as: :instance" do
-      creates_fakes.create(:foo, as: :instance).should == fake_instance
+      expect(creates_fakes.create(:foo, as: :instance)).to eq fake_instance
     end
 
     it "copies class but does not create an instance if called with as: :class" do
-      creates_fakes.create(:foo, as: :class).should == fake_class
+      expect(creates_fakes.create(:foo, as: :class)).to eq fake_class
     end
 
     it "raises an error if the as mode is not known" do
@@ -48,13 +48,13 @@ describe Bogus::CreatesFakes do
     end
 
     it "uses the class provided" do
-      creates_fakes.create(:foo){Bar}.should == fake_instance
+      expect(creates_fakes.create(:foo){Bar}).to eq fake_instance
     end
 
     it "does not convert the class name" do
       creates_fakes.create(:foo) { Bar}
 
-      copies_classes.should_not have_received.convert
+      expect(copies_classes).to_not have_received.convert
     end
   end
 
@@ -68,7 +68,7 @@ describe Bogus::CreatesFakes do
 
       fake = creates_fakes.create(:role, as: :class) { [Foo, Bar] }
 
-      fake.should == :the_fake
+      expect(fake).to eq :the_fake
     end
   end
 end

--- a/spec/bogus/fakes/creates_fakes_with_stubbed_methods_spec.rb
+++ b/spec/bogus/fakes/creates_fakes_with_stubbed_methods_spec.rb
@@ -21,7 +21,7 @@ module Bogus
       end
 
       it "creates fakes" do
-        creates_fakes.should have_created(:foo, {as: :class}, "something")
+        expect(creates_fakes).to have_created(:foo, {as: :class}, "something")
       end
 
       it "stubs all the given methods" do
@@ -35,7 +35,7 @@ module Bogus
       end
 
       it "does not create fakes" do
-        creates_fakes.fakes.should == []
+        expect(creates_fakes.fakes).to eq []
       end
 
       it "stubs all the given methods" do
@@ -51,7 +51,7 @@ module Bogus
       end
 
       it "creates fakes" do
-        creates_fakes.should have_created(:foo, {}, "something")
+        expect(creates_fakes).to have_created(:foo, {}, "something")
       end
 
       it "stubs all the given methods" do
@@ -65,7 +65,7 @@ module Bogus
       end
 
       it "does not create fakes" do
-        creates_fakes.fakes.should == []
+        expect(creates_fakes.fakes).to eq []
       end
 
       it "stubs all the given methods" do
@@ -86,10 +86,10 @@ module Bogus
       end
 
       it "uses the configuration to create fake" do
-        creates_fakes.fakes.should == [fake]
+        expect(creates_fakes.fakes).to eq [fake]
 
-        fake_configuration.should have_received.include?(:foo)
-        fake_configuration.should have_received.get(:foo)
+        expect(fake_configuration).to have_received.include?(:foo)
+        expect(fake_configuration).to have_received.get(:foo)
       end
 
       it "stubs the methods defined in configuration" do
@@ -110,7 +110,7 @@ module Bogus
       end
 
       it "overrides the class block and fake options" do
-        creates_fakes.should have_created(:foo, {as: :instance}, "SomeOtherClass")
+        expect(creates_fakes).to have_created(:foo, {as: :instance}, "SomeOtherClass")
       end
 
       it "overrides the stubbed methods" do

--- a/spec/bogus/fakes/fake_ar_attributes_spec.rb
+++ b/spec/bogus/fakes/fake_ar_attributes_spec.rb
@@ -30,7 +30,7 @@ describe "Stubbing ActiveRecord::Base subclasses" do
   it "makes it possible to stub active record fields" do
     post = fake(:blog_post, name: "hello")
 
-    post.name.should == "hello"
+    expect(post.name).to eq "hello"
   end
 
   it "works only when enabled in configuration" do
@@ -48,7 +48,7 @@ describe "Stubbing ActiveRecord::Base subclasses" do
 
     post.author("hello")
 
-    post.should have_received.author("hello")
+    expect(post).to have_received.author("hello")
   end
 
   class ExampleForActiveRecordAttributes
@@ -61,7 +61,7 @@ describe "Stubbing ActiveRecord::Base subclasses" do
 
     fake.foo(1)
 
-    fake.should have_received.foo(1)
+    expect(fake).to have_received.foo(1)
   end
 
   after do

--- a/spec/bogus/fakes/fake_configuration_spec.rb
+++ b/spec/bogus/fakes/fake_configuration_spec.rb
@@ -4,7 +4,7 @@ describe Bogus::FakeConfiguration do
   let(:config) { Bogus::FakeConfiguration.new }
 
   it "does not contain not configured fakes" do
-    config.include?(:foo).should be_false
+    expect(config.include?(:foo)).to be_false
   end
 
   def class_block(name)
@@ -26,8 +26,8 @@ describe Bogus::FakeConfiguration do
       end
     end
 
-    config.include?(:foo).should be_true
-    config.include?(:bar).should be_false
+    expect(config.include?(:foo)).to be_true
+    expect(config.include?(:bar)).to be_false
   end
 
   it "returns the configuration for a fake" do
@@ -37,9 +37,9 @@ describe Bogus::FakeConfiguration do
       end
     end
 
-    opts(:foo).should == {as: :class}
-    stubs(:foo).should == {bar: "the bar"}
-    class_block(:foo).call.should == Samples::Foo
+    expect(opts(:foo)).to eq ({ as: :class} )
+    expect(stubs(:foo)).to eq ({ bar: "the bar"} )
+    expect(class_block(:foo).call).to eq Samples::Foo
   end
 
   context "with no class" do
@@ -48,9 +48,9 @@ describe Bogus::FakeConfiguration do
         fake(:foo, as: :class) { bar "bar" }
       end
 
-      opts(:foo).should == {as: :class}
-      stubs(:foo).should == {bar: "bar"}
-      class_block(:foo).should be_nil
+      expect(opts(:foo)).to eq ({ as: :class} )
+      expect(stubs(:foo)).to eq ({ bar: "bar"} )
+      expect(class_block(:foo)).to be_nil
     end
   end
 
@@ -60,9 +60,9 @@ describe Bogus::FakeConfiguration do
         fake(:foo) { bar "bar" }
       end
 
-      opts(:foo).should == {}
-      stubs(:foo).should == {bar: "bar"}
-      class_block(:foo).should be_nil
+      expect(opts(:foo)).to eq ({ } )
+      expect(stubs(:foo)).to eq ({ bar: "bar"} )
+      expect(class_block(:foo)).to be_nil
     end
   end
 
@@ -72,7 +72,7 @@ describe Bogus::FakeConfiguration do
         fake(:foo) { bar {"bar"} }
       end
 
-      stubs(:foo)[:bar].call.should == "bar"
+      expect(stubs(:foo)[:bar].call).to eq "bar"
     end
 
     it "does not evaluate the blocks when getting, nor when setting" do
@@ -91,9 +91,9 @@ describe Bogus::FakeConfiguration do
         fake(:foo, as: :class)
       end
 
-      opts(:foo).should == {as: :class}
-      stubs(:foo).should == {}
-      class_block(:foo).should be_nil
+      expect(opts(:foo)).to eq ({ as: :class} )
+      expect(stubs(:foo)).to eq ({ } )
+      expect(class_block(:foo)).to be_nil
     end
   end
 end

--- a/spec/bogus/fakes/fake_registry_spec.rb
+++ b/spec/bogus/fakes/fake_registry_spec.rb
@@ -8,7 +8,7 @@ describe Bogus::FakeRegistry do
 
     fake_registry.store(:name, object)
 
-    fake_registry.name(object).should == :name
+    expect(fake_registry.name(object)).to eq :name
   end
 
   it "returns name based on object identity" do
@@ -19,6 +19,6 @@ describe Bogus::FakeRegistry do
 
     fake_registry.store(:object, object)
 
-    fake_registry.name(duplicate).should be_nil
+    expect(fake_registry.name(duplicate)).to be_nil
   end
 end

--- a/spec/bogus/fakes/fake_spec.rb
+++ b/spec/bogus/fakes/fake_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Bogus::Fake do
   it 'has a class name' do
-    Bogus::Fake.name.should == "Bogus::Fake"
+    expect(Bogus::Fake.name).to eq "Bogus::Fake"
   end
 end
 

--- a/spec/bogus/fakes/fakes_classes_spec.rb
+++ b/spec/bogus/fakes/fakes_classes_spec.rb
@@ -20,7 +20,7 @@ describe Bogus::FakesClasses do
   it "creates a fake named after the class" do
     fakes_classes.fake(Samples::WillBeOverwritten, foo: "bar")
 
-    creates_fakes_with_stubbed_methods.should have_created(:will_be_overwritten,
+    expect(creates_fakes_with_stubbed_methods).to have_created(:will_be_overwritten,
                                                            {as: :class, foo: "bar"}, Samples::WillBeOverwritten)
   end
 
@@ -29,18 +29,18 @@ describe Bogus::FakesClasses do
 
     fakes_classes.fake(Samples::WillBeOverwritten)
 
-    overwrites_classes.should have_received.overwrite("Samples::WillBeOverwritten", fake)
+    expect(overwrites_classes).to have_received.overwrite("Samples::WillBeOverwritten", fake)
   end
 
   it "stores the overwritten class so that it can be replaced back later" do
     fakes_classes.fake(Samples::WillBeOverwritten)
 
-    overwritten_classes.should have_received.add("Samples::WillBeOverwritten", Samples::WillBeOverwritten)
+    expect(overwritten_classes).to have_received.add("Samples::WillBeOverwritten", Samples::WillBeOverwritten)
   end
 
   it "uses the passed fake name if provided" do
     fakes_classes.fake(Samples::WillBeOverwritten, fake_name: :foo_bar)
 
-    creates_fakes_with_stubbed_methods.should have_created(:foo_bar, {as: :class}, Samples::WillBeOverwritten)
+    expect(creates_fakes_with_stubbed_methods).to have_created(:foo_bar, {as: :class}, Samples::WillBeOverwritten)
   end
 end

--- a/spec/bogus/fakes/faking_factories_spec.rb
+++ b/spec/bogus/fakes/faking_factories_spec.rb
@@ -24,7 +24,7 @@ describe "Faking Factories" do
 
     factory.create(2)
 
-    model_class.should have_received.new(1, 2)
+    expect(model_class).to have_received.new(1, 2)
   end
 
   class ExampleModel2
@@ -49,7 +49,7 @@ describe "Faking Factories" do
 
     model = model_class.new
 
-    model_class.should have_received.new
+    expect(model_class).to have_received.new
   end
 
   class ExampleModel4
@@ -65,7 +65,7 @@ describe "Faking Factories" do
 
     model.foo(1)
 
-    model.should have_received.foo(1)
+    expect(model).to have_received.foo(1)
   end
 
   module ExampleModel5
@@ -78,6 +78,6 @@ describe "Faking Factories" do
 
     model.foo(1)
 
-    model.should have_received.foo(1)
+    expect(model).to have_received.foo(1)
   end
 end

--- a/spec/bogus/fakes/frozen_fakes_spec.rb
+++ b/spec/bogus/fakes/frozen_fakes_spec.rb
@@ -15,7 +15,7 @@ describe "Frozen Fakes" do
       it "allows stubbing" do
         stub(object).foo(1) { 123 }
 
-        object.foo(1).should == 123
+        expect(object.foo(1)).to eq 123
       end
     end
 
@@ -23,7 +23,7 @@ describe "Frozen Fakes" do
       it "allows mocking" do
         mock(object).foo(1) { 123 }
 
-        object.foo(1).should == 123
+        expect(object.foo(1)).to eq 123
       end
 
       it "allows verifying expectations" do
@@ -39,8 +39,8 @@ describe "Frozen Fakes" do
       it "allows spying" do
         object.foo(1)
 
-        object.should have_received.foo(1)
-        object.should_not have_received.foo(2)
+        expect(object).to have_received.foo(1)
+        expect(object).to_not have_received.foo(2)
       end
     end
   end

--- a/spec/bogus/fakes/instance_methods_spec.rb
+++ b/spec/bogus/fakes/instance_methods_spec.rb
@@ -16,7 +16,7 @@ module Bogus
     let(:instance_methods) { InstanceMethods.new(SampleClass) }
 
     it "lists the instance methods" do
-      instance_methods.all.should =~ [:foo, :hello]
+      expect(instance_methods.all).to match_array([:foo, :hello])
     end
 
     it "returns the instance methods by name" do
@@ -27,7 +27,7 @@ module Bogus
     it "removes methods by name" do
       instance_methods.remove(:hello)
 
-      SampleClass.new.should_not respond_to(:hello)
+      expect(SampleClass.new).to_not respond_to(:hello)
     end
 
     it "defines instance methods" do
@@ -39,7 +39,7 @@ module Bogus
 
       instance = SampleClass.new
 
-      instance.greet("Joe").should == "Hello, Joe!"
+      expect(instance.greet("Joe")).to eq "Hello, Joe!"
     end
   end
 end

--- a/spec/bogus/fakes/makes_ducks_spec.rb
+++ b/spec/bogus/fakes/makes_ducks_spec.rb
@@ -40,7 +40,7 @@ module Bogus
       it { should respond_to(:foo) }
 
       it "should have arity -3 for foo" do
-        duck.method(:foo).arity.should == -3
+        expect(duck.method(:foo).arity).to eq -3
       end
 
       it { should_not respond_to(:bar) }
@@ -76,11 +76,11 @@ module Bogus
       end
 
       it "copies class methods" do
-        duck.should respond_to(:enabled?)
+        expect(duck).to respond_to(:enabled?)
       end
 
       it "copies instance methods" do
-        duck_instance.should respond_to(:enabled?)
+        expect(duck_instance).to respond_to(:enabled?)
       end
     end
   end

--- a/spec/bogus/fakes/makes_substitute_methods_spec.rb
+++ b/spec/bogus/fakes/makes_substitute_methods_spec.rb
@@ -14,7 +14,7 @@ module Bogus
     it "makes a copy of the method with its params and adds recording" do
       copy = makes_substitute_methods.stringify(SampleForCopyingMethods.method(:foo))
 
-      copy.should == <<-EOF
+      expect(copy).to eq <<-EOF
       def foo(name, value = Bogus::DefaultValue, *rest, &block)
         __record__(:foo, name, value, *rest, &block)
       end

--- a/spec/bogus/fakes/overwriten_classes_spec.rb
+++ b/spec/bogus/fakes/overwriten_classes_spec.rb
@@ -9,7 +9,7 @@ describe Bogus::OverwrittenClasses do
     overwritten_classes.add("Foo::Bar", klass)
     overwritten_classes.add("Baz::Bam", klass)
 
-    overwritten_classes.classes.should == [["Foo::Bar", klass],
+    expect(overwritten_classes.classes).to eq [["Foo::Bar", klass],
                                            ["Baz::Bam", klass]]
   end
 
@@ -18,10 +18,10 @@ describe Bogus::OverwrittenClasses do
     overwritten_classes.add("Baz::Bam", klass)
     overwritten_classes.clear
 
-    overwritten_classes.classes.should == []
+    expect(overwritten_classes.classes).to eq []
   end
 
   it "returns an empty array with no classes" do
-    overwritten_classes.classes.should == []
+    expect(overwritten_classes.classes).to eq []
   end
 end

--- a/spec/bogus/fakes/overwrites_classes_spec.rb
+++ b/spec/bogus/fakes/overwrites_classes_spec.rb
@@ -14,13 +14,13 @@ describe Bogus::OverwritesClasses do
   it "overwrites nested classes" do
     overwrites_classes.overwrite('SampleOuterModule::SampleModule::SampleClass', new_class)
 
-    SampleOuterModule::SampleModule::SampleClass.should equal(new_class)
+    expect(SampleOuterModule::SampleModule::SampleClass).to equal(new_class)
   end
 
   it "overwrites top level classes" do
     overwrites_classes.overwrite('SampleOuterModule', new_class)
 
-    SampleOuterModule.should equal(new_class)
+    expect(SampleOuterModule).to equal(new_class)
   end
 end
 

--- a/spec/bogus/fakes/registers_created_fakes_spec.rb
+++ b/spec/bogus/fakes/registers_created_fakes_spec.rb
@@ -16,18 +16,18 @@ describe Bogus::RegistersCreatedFakes do
   it "registers the fakes created by creates_fakes" do
     registers_created_fakes.create(:foo, as: :instance) { Object }
 
-    fake_registry.should have_received.store(:foo, :the_fake)
+    expect(fake_registry).to have_received.store(:foo, :the_fake)
   end
 
   it "tracks the created fakes for purposes of mock expectations" do
     registers_created_fakes.create(:foo, as: :instance) { Object }
 
-    double_tracker.should have_received.track(:the_fake)
+    expect(double_tracker).to have_received.track(:the_fake)
   end
 
   it "returns the created fake" do
     fake = registers_created_fakes.create(:foo, as: :instance) { Object }
 
-    fake.should == :the_fake
+    expect(fake).to eq :the_fake
   end
 end

--- a/spec/bogus/fakes/resets_overwritten_classes_spec.rb
+++ b/spec/bogus/fakes/resets_overwritten_classes_spec.rb
@@ -16,11 +16,11 @@ describe Bogus::ResetsOverwrittenClasses do
   end
 
   it "overwrites back all of the overwritten classes" do
-    overwrites_classes.should have_received.overwrite('Foo', :foo)
-    overwrites_classes.should have_received.overwrite('Bar', :bar)
+    expect(overwrites_classes).to have_received.overwrite('Foo', :foo)
+    expect(overwrites_classes).to have_received.overwrite('Bar', :bar)
   end
 
   it "clears the overwritten classes" do
-    overwritten_classes.should have_received.clear
+    expect(overwritten_classes).to have_received.clear
   end
 end

--- a/spec/bogus/mocking_dsl_spec.rb
+++ b/spec/bogus/mocking_dsl_spec.rb
@@ -30,25 +30,25 @@ describe Bogus::MockingDSL do
     it "allows stubbing the existing methods" do
       Stubber.stub(baz).foo("bar") { :return_value }
 
-      baz.foo("bar").should == :return_value
+      expect(baz.foo("bar")).to eq :return_value
     end
 
     it "can stub method with any parameters" do
       Stubber.stub(baz).foo(Stubber.any_args) { :default_value }
       Stubber.stub(baz).foo("bar") { :foo_value }
 
-      baz.foo("a").should == :default_value
-      baz.foo("b").should == :default_value
-      baz.foo("bar").should == :foo_value
+      expect(baz.foo("a")).to eq :default_value
+      expect(baz.foo("b")).to eq :default_value
+      expect(baz.foo("bar")).to eq :foo_value
     end
 
     it "can stub method with some wildcard parameters" do
       Stubber.stub(baz).hello(Stubber.any_args) { :default_value }
       Stubber.stub(baz).hello("welcome", Stubber.anything) { :greeting_value }
 
-      baz.hello("hello", "adam").should == :default_value
-      baz.hello("welcome", "adam").should == :greeting_value
-      baz.hello("welcome", "rudy").should == :greeting_value
+      expect(baz.hello("hello", "adam")).to eq :default_value
+      expect(baz.hello("welcome", "adam")).to eq :greeting_value
+      expect(baz.hello("welcome", "rudy")).to eq :greeting_value
     end
 
     it "does not allow stubbing non-existent methods" do
@@ -63,7 +63,7 @@ describe Bogus::MockingDSL do
 
       Bogus.after_each_test
 
-      ExampleFoo.bar("John").should == "Hello John"
+      expect(ExampleFoo.bar("John")).to eq "Hello John"
     end
   end
 
@@ -74,25 +74,25 @@ describe Bogus::MockingDSL do
       it "allows verifying that fakes have correct interfaces" do
         the_fake.foo("test")
 
-        the_fake.should Stubber.have_received.foo("test")
+        expect(the_fake).to Stubber.have_received.foo("test")
       end
 
       it "does not allow verifying on non-existent methods" do
         expect {
-          the_fake.should Stubber.have_received.bar("test")
+          expect(the_fake).to Stubber.have_received.bar("test")
         }.to raise_error(NameError)
       end
 
       it "does not allow verifying on methods with a wrong argument count" do
         expect {
-          the_fake.should Stubber.have_received.foo("test", "test 2")
+          expect(the_fake).to Stubber.have_received.foo("test", "test 2")
         }.to raise_error(ArgumentError)
       end
 
       it "allows spying on methods with optional parameters" do
         the_fake.with_optional_args(123)
 
-        the_fake.should Stubber.have_received.with_optional_args(123)
+        expect(the_fake).to Stubber.have_received.with_optional_args(123)
       end
     end
 
@@ -102,16 +102,16 @@ describe Bogus::MockingDSL do
 
       object.foo('test')
 
-      object.should Stubber.have_received.foo("test")
+      expect(object).to Stubber.have_received.foo("test")
     end
 
     it "allows spying on methods with optional parameters" do
       object = ExampleFoo.new
       Stubber.stub(object).with_optional_args(123) { 999 }
 
-      object.with_optional_args(123).should == 999
+      expect(object.with_optional_args(123)).to eq 999
 
-      object.should Stubber.have_received.with_optional_args(123)
+      expect(object).to Stubber.have_received.with_optional_args(123)
     end
 
     class ClassWithMatches
@@ -124,7 +124,7 @@ describe Bogus::MockingDSL do
 
       fake.matches?("foo")
 
-      fake.should Bogus.have_received.matches?("foo")
+      expect(fake).to Bogus.have_received.matches?("foo")
     end
 
     class PassesSelfToCollaborator
@@ -141,7 +141,7 @@ describe Bogus::MockingDSL do
 
       object.hello(fake)
 
-      fake.should Bogus.have_received.foo(object)
+      expect(fake).to Bogus.have_received.foo(object)
     end
   end
 
@@ -157,7 +157,7 @@ describe Bogus::MockingDSL do
       it "allows mocking on methods with optional parameters" do
         Mocker.mock(baz).with_optional_args(1) { :return }
 
-        baz.with_optional_args(1).should == :return
+        expect(baz.with_optional_args(1)).to eq :return
 
         expect { Bogus.after_each_test }.not_to raise_error
       end
@@ -165,7 +165,7 @@ describe Bogus::MockingDSL do
       it "allows mocking with anything" do
         Mocker.mock(baz).hello(1, Bogus::Anything) { :return }
 
-        baz.hello(1, 2).should == :return
+        expect(baz.hello(1, 2)).to eq :return
 
         expect { Bogus.after_each_test }.not_to raise_error
       end
@@ -173,7 +173,7 @@ describe Bogus::MockingDSL do
       it "allows mocking the existing methods" do
         Mocker.mock(baz).foo("bar") { :return_value }
 
-        baz.foo("bar").should == :return_value
+        expect(baz.foo("bar")).to eq :return_value
 
         expect { Bogus.after_each_test }.not_to raise_error
       end
@@ -246,7 +246,7 @@ describe Bogus::MockingDSL do
 
       stub(greeter).greet("Jake") { "Hello Jake" }
 
-      greeter.greet("Jake").should == "Hello Jake"
+      expect(greeter.greet("Jake")).to eq "Hello Jake"
     end
 
     it "creates objects that can be mocked" do
@@ -254,13 +254,13 @@ describe Bogus::MockingDSL do
 
       mock(greeter).greet("Jake") { "Hello Jake" }
 
-      greeter.greet("Jake").should == "Hello Jake"
+      expect(greeter.greet("Jake")).to eq "Hello Jake"
     end
 
     it "creates objects with some methods stubbed by default" do
       greeter = fake(greet: "Hello Jake")
 
-      greeter.greet("Jake").should == "Hello Jake"
+      expect(greeter.greet("Jake")).to eq "Hello Jake"
     end
 
     it "creates objects that can be spied upon" do
@@ -268,8 +268,8 @@ describe Bogus::MockingDSL do
 
       greeter.greet("Jake")
 
-      greeter.should have_received.greet("Jake")
-      greeter.should_not have_received.greet("Bob")
+      expect(greeter).to have_received.greet("Jake")
+      expect(greeter).to_not have_received.greet("Bob")
     end
 
     it "verifies mock expectations set on anonymous fakes" do
@@ -307,15 +307,15 @@ describe Bogus::MockingDSL do
     it "returns configured fakes" do
       the_fake = Stubber.fake(:globally_configured_fake)
 
-      the_fake.foo('a').should == "foo"
-      the_fake.bar('a', 'b').should == "bar"
+      expect(the_fake.foo('a')).to eq "foo"
+      expect(the_fake.bar('a', 'b')).to eq "bar"
     end
 
     it "allows overwriting stubbed methods" do
       the_fake = Stubber.fake(:globally_configured_fake, bar: "baz")
 
-      the_fake.foo('a').should == "foo"
-      the_fake.bar('a', 'b').should == "baz"
+      expect(the_fake.foo('a')).to eq "foo"
+      expect(the_fake.bar('a', 'b')).to eq "baz"
     end
 
     it "evaluates the block passed to method in configuration when method is called" do
@@ -340,8 +340,8 @@ describe Bogus::MockingDSL do
     it "replaces the class for the duration of the test" do
       Stubber.fake_class(ThisClassWillBeReplaced, hello: "replaced!")
 
-      ThisClassWillBeReplaced.hello("foo").should == "replaced!"
-      ThisClassWillBeReplaced.should_not equal(TheOriginalClass)
+      expect(ThisClassWillBeReplaced.hello("foo")).to eq "replaced!"
+      expect(ThisClassWillBeReplaced).to_not equal(TheOriginalClass)
     end
 
     it "makes it possible to spy on classes" do
@@ -349,15 +349,15 @@ describe Bogus::MockingDSL do
 
       ThisClassWillBeReplaced.hello("foo")
 
-      ThisClassWillBeReplaced.should Bogus.have_received.hello("foo")
-      ThisClassWillBeReplaced.should_not Bogus.have_received.hello("bar")
+      expect(ThisClassWillBeReplaced).to Bogus.have_received.hello("foo")
+      expect(ThisClassWillBeReplaced).to_not Bogus.have_received.hello("bar")
     end
 
     it "restores the class after the test has finished" do
       Stubber.fake_class(ThisClassWillBeReplaced)
       Bogus.reset_overwritten_classes
 
-      ThisClassWillBeReplaced.should equal(TheOriginalClass)
+      expect(ThisClassWillBeReplaced).to equal(TheOriginalClass)
     end
   end
 
@@ -385,7 +385,7 @@ describe Bogus::MockingDSL do
     end
 
     it "passes when all the mocked interactions were executed" do
-      sample.greet("Welcome").should == "Welcome, John!"
+      expect(sample.greet("Welcome")).to eq "Welcome, John!"
 
       Bogus.after_each_test
 
@@ -395,7 +395,7 @@ describe Bogus::MockingDSL do
     end
 
     it "fails when contracts are fullfilled" do
-      sample.greet("Hello").should == "Hello, John!"
+      expect(sample.greet("Hello")).to eq "Hello, John!"
 
       Bogus.after_each_test
 

--- a/spec/bogus/ruby_2_support_spec.rb
+++ b/spec/bogus/ruby_2_support_spec.rb
@@ -15,14 +15,14 @@ if RUBY_VERSION >= '2.0'
 
         subject.foo(x: "test")
 
-        subject.should have_received.foo(x: "test")
-        subject.should_not have_received.foo(x: "baz")
+        expect(subject).to have_received.foo(x: "test")
+        expect(subject).to_not have_received.foo(x: "baz")
       end
 
       it "can mock methods with keyword arguments" do
         mock(subject).foo(x: 1) { :return }
 
-        subject.foo(x: 1).should == :return
+        expect(subject.foo(x: 1)).to eq :return
 
         expect { Bogus.after_each_test }.not_to raise_error
       end
@@ -30,7 +30,7 @@ if RUBY_VERSION >= '2.0'
       it "can stub methods with keyword arguments" do
         stub(subject).foo(x: "bar") { :return_value }
 
-        subject.foo(x: "bar").should == :return_value
+        expect(subject.foo(x: "bar")).to eq :return_value
       end
 
       it "raises on error on unknown keyword" do
@@ -54,14 +54,14 @@ if RUBY_VERSION >= '2.0'
 
         subject.bar(x: "test", z: "spec")
 
-        subject.should have_received.bar(x: "test", z: "spec")
-        subject.should_not have_received.bar(y: "baz")
+        expect(subject).to have_received.bar(x: "test", z: "spec")
+        expect(subject).to_not have_received.bar(y: "baz")
       end
 
       it "can mock methods with keyword arguments" do
         mock(subject).bar(x: 1, z: 2) { :return }
 
-        subject.bar(x: 1, z: 2).should == :return
+        expect(subject.bar(x: 1, z: 2)).to eq :return
 
         expect { Bogus.after_each_test }.not_to raise_error
       end
@@ -69,7 +69,7 @@ if RUBY_VERSION >= '2.0'
       it "can stub methods with keyword arguments" do
         stub(subject).bar(x: "bar", z: "bar") { :return_value }
 
-        subject.bar(x: "bar", z: "bar").should == :return_value
+        expect(subject.bar(x: "bar", z: "bar")).to eq :return_value
       end
     end
 
@@ -86,7 +86,7 @@ if RUBY_VERSION >= '2.0'
       it "allows spying without stubbing" do
         subject.foo(x: "test")
 
-        subject.should have_received.foo(x: "test")
+        expect(subject).to have_received.foo(x: "test")
       end
 
       include_examples "stubbing methods with keyword arguments"


### PR DESCRIPTION
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I noticed that expect is now being used in many of the major gems that use rspec and I'd like to offer this change from the should format to the expect format for consideration.
I also changed the pattern matchers from =~ to match() or match_array() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post. 
All previously passing tests still pass after this change.
I've tried to be careful to observe the existing style and structure with my proposed changes.
