### PR TITLE
gracefully handle missing coveralls gem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require 'simplecov'
-require 'coveralls'
+begin
+  require "coveralls"
+rescue LoadError
+  warn "warning: coveralls gem not found; skipping Coveralls"
+end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
If we do not have coveralls installed, we should be able to continue with the rest of the test suite.

This allows the test suite to work outside of bundler when coveralls is not available.

In the ordinary development case, it would work to use `bundle install` and run the tests through bundler, which would load the coveralls gem. Since I'm packaging bogus for Fedora, I can't really use bundler in the RPM packaging.
