### PR TITLE
remove Ruby 1.9.2 from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0
   - jruby-19mode


### PR DESCRIPTION
The "listen" gem is in the dependency chain for bogus, and this listen gem has a hard requirement on Ruby 1.9.3 or later. This causes the bogus travis builds to fail on Ruby 1.9.2.

Since Ruby 1.9.2 is deprecated, remove it from the Travis configuration.
