### PR TITLE
permit ActiveRecord 4 in gemspec

### DIFF
--- a/bogus.gemspec
+++ b/bogus.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'relish'
   s.add_development_dependency 'coveralls'
 
-  s.add_development_dependency 'activerecord', '>= 3', '< 4'
+  s.add_development_dependency 'activerecord', '>= 3', '< 5'
   s.add_development_dependency 'activerecord-nulldb-adapter'
 
   s.add_development_dependency 'minitest', '>= 4.7'


### PR DESCRIPTION
Previously we could not allow ActiveRecord 4 because the activerecord-nulldb-adapter gem did not support ActiveSupport 4 in any released version.

The activerecord-nulldb-adapter maintainers have recently released version 0.3.0, and this version is compatible with ActiveSupport 4.

This pull request bumps the bogus gemspec ActiveRecord version to reflect the fact that we can now support ActiveRecord 4 as well.
