### PR TITLE
Remove deprecation warning for Rspec 3.0.0 in have_received matcher

### DIFF
--- a/lib/bogus/stubbing/have_received_matcher.rb
+++ b/lib/bogus/stubbing/have_received_matcher.rb
@@ -21,15 +21,17 @@ module Bogus
       "have received #{call_str(@name, @args)}"
     end
 
-    def failure_message_for_should
+    def failure_message
       return NO_SHADOW unless Shadow.has_shadow?(@subject)
       %Q{Expected #{@subject.inspect} to #{description}, but it didn't.\n\n} + all_calls_str
     end
+    alias_method :failure_message_for_should, :failure_message
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       return NO_SHADOW unless Shadow.has_shadow?(@subject)
       %Q{Expected #{@subject.inspect} not to #{description}, but it did.}
     end
+    alias_method :failure_message_for_should_not, :failure_message_when_negated
 
     def method_call
       proxy(:set_method)

--- a/spec/bogus/stubbing/have_received_matcher_spec.rb
+++ b/spec/bogus/stubbing/have_received_matcher_spec.rb
@@ -41,7 +41,9 @@ describe Bogus::HaveReceivedMatcher do
 
       have_received_matcher.matches?("foo").should be_false
       have_received_matcher.failure_message_for_should.should == Bogus::HaveReceivedMatcher::NO_SHADOW
+      have_received_matcher.failure_message.should == Bogus::HaveReceivedMatcher::NO_SHADOW
       have_received_matcher.failure_message_for_should_not.should == Bogus::HaveReceivedMatcher::NO_SHADOW
+      have_received_matcher.failure_message_when_negated.should == Bogus::HaveReceivedMatcher::NO_SHADOW
     end
 
     it "returns a readable error message for fakes" do
@@ -49,10 +51,13 @@ describe Bogus::HaveReceivedMatcher do
 
       have_received_matcher.matches?(fake)
 
-      have_received_matcher.failure_message_for_should.should ==
+      message = 
         %Q{Expected #{fake.inspect} to have received foo("a", "c"), but it didn't.\n\n}+
         %Q{The recorded interactions were:\n} +
         %Q{  - foo("a", "b")\n}
+
+      have_received_matcher.failure_message_for_should.should == message
+      have_received_matcher.failure_message.should == message
     end
   end
 


### PR DESCRIPTION
Those deprecation warnings are really annoying and Rspec 3 is coming rather sooner than later - more and more people are using it right now without the stable release.

This pull request is using the new `failure_message` and `failure_message_when_negated` and aliasing the deprecated `failure_message_for_should` and `failure_message_for_should_not` for backward compatibility.
