### PR TITLE
avoid dependency on Coveralls::SimpleCov::Formatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
 require 'simplecov'
 begin
   require "coveralls"
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter]
 rescue LoadError
   warn "warning: coveralls gem not found; skipping Coveralls"
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 end
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter]
 
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
In 5b8bb36e3e27d4db13541f294a7c42d74eb417b2, bogus gained the ability to run the test suite without Coveralls. There was a bug in this implementation: if we do not have coveralls installed, we can't refer to Coveralls constants later on.

This pull request moves the Coverall reference inside the conditional.
