### PR TITLE
tests: use rspec 3 color configuration API

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,14 @@ require_relative 'support/matchers'
 require_relative 'support/shared_examples_for_keyword_arguments'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  if config.respond_to? :color=
+    # RSpec 3
+    config.color = true
+  end
+  if config.respond_to? :color_enabled=
+    # RSpec 2
+    config.color_enabled = true
+  end
   config.mock_framework = :rr
 end
 


### PR DESCRIPTION
rspec 3.0.0.rc1 removed the `color_enabled` configuration option in favor of the newer `color` option.

Travis still fails because the tests themselves have not been ported to the RSpec 3 API, but this gets us a bit closer.
