### PR TITLE
Properly namespace ::Minitest (to not clash with Bogus::Minitest)

### DIFF
--- a/lib/bogus/minitest.rb
+++ b/lib/bogus/minitest.rb
@@ -38,8 +38,8 @@ module Bogus::Minitest
 end
 
 # minitest 5 vs 4.7
-if defined? Minitest::Test
-  class Minitest::Test
+if defined? ::Minitest::Test
+  class ::Minitest::Test
     include Bogus::Minitest
   end
 else

--- a/lib/bogus/minitest/syntax.rb
+++ b/lib/bogus/minitest/syntax.rb
@@ -17,8 +17,8 @@ module Bogus
 
     def after_suite(&block)
       # minitest 5 vs 4.7
-      if defined? Minitest.after_run
-        Minitest.after_run(&block)
+      if defined? ::Minitest.after_run
+        ::Minitest.after_run(&block)
       else
         MiniTest::Unit.after_tests(&block)
       end


### PR DESCRIPTION
I noticed an irritating warning when verifying contract tests:

```
MiniTest::Unit.after_tests is now Minitest.after_run.
From …/lib/bogus/minitest/syntax.rb:23:in `after_suite'`
```

This fixes the warning by making sure the right (top-level) `Minitest` is being looked for.