### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby
   - rbx
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0
-  - 2.1.1
+  - 2.0.0
+  - 2.1
   - jruby
   - rbx
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_install:
   - rvm uninstall jruby
   - rvm use jruby-1.7.18 --install
 script: bundle exec rspec spec && bundle exec cucumber --tag ~@wip
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,5 @@ rvm:
   - 2.2
   - jruby
   - rbx
-before_install:
-  - rvm uninstall jruby
-  - rvm use jruby-1.7.18 --install
 script: bundle exec rspec spec && bundle exec cucumber --tag ~@wip
 sudo: false


### PR DESCRIPTION
A few `.travis.yml` fixes:

* use proper Ruby version (2.0.0 but 2.1),
* add Ruby 2.2,
* drop the no-longer-needed JRuby 1.7 workaround,
* use containers.

Result: better Ruby version coverage and build time drop from ~40 minutes to ~14 minutes.