### PR TITLE
Pin aruba to a version that still builds

### DIFF
--- a/bogus.gemspec
+++ b/bogus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'cucumber'
-  s.add_development_dependency 'aruba'
+  s.add_development_dependency 'aruba', '~> 0.9.0'
 
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-rspec'


### PR DESCRIPTION
Aruba is quick to drop backwards compatibility in 0.x releases, and this is why master doesn’t build.

This pins aruba to a version that still works. I’ll come up with fixes to forward-port Bogus later this month, but I’d rather the master was green for the sake of other PRs.