### PR TITLE
Fix warnigns raised on Ruby 2.6

### DIFF
--- a/bogus.gemspec
+++ b/bogus.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Create fakes to make your isolated unit tests reliable.}
   s.description = %q{Decreases the need to write integration tests by ensuring that the things you stub or mock actually exist.}
 
-  s.rubyforge_project = "bogus"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/bogus.gemspec
+++ b/bogus.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'wwtd'
 
-  s.add_development_dependency 'activerecord', '>= 3', '< 5'
+  s.add_development_dependency 'activerecord', '>= 3', '< 7'
   s.add_development_dependency 'activerecord-nulldb-adapter'
 
   s.add_development_dependency 'minitest', '>= 4.7'

--- a/spec/bogus/fakes/fake_configuration_spec.rb
+++ b/spec/bogus/fakes/fake_configuration_spec.rb
@@ -81,7 +81,7 @@ describe Bogus::FakeConfiguration do
       end
 
       block = stubs(:foo)[:bar]
-      expect{ block.call }.to raise_error
+      expect{ block.call }.to raise_error RuntimeError
     end
   end
 

--- a/spec/bogus/stubbing/double_spec.rb
+++ b/spec/bogus/stubbing/double_spec.rb
@@ -14,7 +14,7 @@ module Bogus
 
         expect {
           double_instance.stub.foo("a", "b") { "the result" }
-        }.to raise_error
+        }.to raise_error NameError
 
         expect(double_tracker).not_to have_received(:track).with(object)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 require 'simplecov'
 begin
   require "coveralls"
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter]
+    Coveralls::SimpleCov::Formatter])
 rescue LoadError
   warn "warning: coveralls gem not found; skipping Coveralls"
   SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter


### PR DESCRIPTION
These changes fix warnings for test runs under Ruby 2.6.