### PR TITLE
Fix block and rest names on Ruby 2.7

### DIFF
--- a/lib/bogus/fakes/method_stringifier.rb
+++ b/lib/bogus/fakes/method_stringifier.rb
@@ -27,12 +27,12 @@ module Bogus
 
     def argument_to_string(name, type, default)
       case type
-      when :block then "&#{name}"
+      when :block then "&#{name == :& ? 'block' : name}"
       when :key then default ? "#{name}: #{default}" : "#{name}: #{name}"
       when :keyreq then default ? "#{name}:" : "#{name}: #{name}"
       when :opt then default ? "#{name} = #{default}" : name
       when :req then name
-      when :rest then "*#{name}"
+      when :rest then "*#{name == :* ? 'rest' : name}"
       when :keyrest then "**#{name}"
       else raise "unknown argument type: #{type}"
       end


### PR DESCRIPTION
Running `rspec` on Ruby 2.7 blows up: 
```
     Failure/Error: klass.instance_eval(body)

     SyntaxError:
       (eval):1: syntax error, unexpected &&, expecting & or '&'
             def forty_two!(**, &&)
                                ^~
       (eval):2: syntax error, unexpected ','
       ...    __record__(:forty_two!, **, &&)
       ...                              ^
```

This renames the `block` and `rest` symbols from `:&` and `:*` so the code generation works.